### PR TITLE
Don't skip first transaction

### DIFF
--- a/src/ofxstatement/plugins/belfius.py
+++ b/src/ofxstatement/plugins/belfius.py
@@ -68,9 +68,7 @@ class BelfiusParser(CsvStatementParser):
     def split_records(self):
         """Return iterable object consisting of a line per transaction
         """
-        reader = csv.reader(self.fin, 'belfiuscsv')
-        next(reader, None)
-        return reader
+        return csv.reader(self.fin, 'belfiuscsv')
 
     def parse_record(self, line):
         """Parse given transaction line and return StatementLine object


### PR DESCRIPTION
This patch prevents the first transaction from being skipped during the conversion from .csv to .ofx.